### PR TITLE
Remove duplicate tmux settings handled by tmux-sensible plugin

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -13,9 +13,6 @@ run '/opt/homebrew/opt/tpm/share/tpm/tpm'
 set -g default-terminal "screen-256color"
 set -ga terminal-overrides ",*256col*:Tc"
 
-# Scrollback
-set -g history-limit 90000
-
 # Prefix keys
 set -g prefix C-z
 unbind C-b
@@ -27,21 +24,11 @@ set -g pane-base-index 1
 set-window-option -g pane-base-index 1
 set -g renumber-windows on
 
-# Faster command sequences
-set -sg escape-time 1
-
-# Vim keys in copy mode, emacs status line
+# Vim keys in copy mode
 set -g mode-keys vi
-set -g status-keys emacs
 
 # Mouse control
 set -g mouse on
-
-# Focus events for terminals that support them and neovim
-set -g focus-events on
-
-# Longer display time for messages
-set -g display-time 3000
 
 # Status bar with hostname
 set -g status-style 'bg=#333333 fg=cyan'


### PR DESCRIPTION
Removed five settings that duplicate tmux-sensible defaults:
- history-limit: tmux-sensible sets 50000 (removed 90000 override)
- escape-time: tmux-sensible sets 0 (removed 1ms delay)
- status-keys: tmux-sensible sets emacs by default
- focus-events: tmux-sensible enables by default
- display-time: tmux-sensible sets 4000 (removed 3000 override)